### PR TITLE
RDAODTD-2327: Tag-based mask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get update \
 && apt-get clean
 
 COPY --from=builder /home/src/main/resources/application.properties application.properties
-COPY --from=builder /home/target/datahub-webapi-1.6.0.jar datahub-webapi-1.6.0.jar
+COPY --from=builder /home/target/datahub-webapi-1.7.0.jar datahub-webapi-1.7.0.jar
 
-ENTRYPOINT ["sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -jar /datahub-webapi-1.6.0.jar" ]
+ENTRYPOINT ["sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -jar /datahub-webapi-1.7.0.jar" ]

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The API requires the following environment variables
 The API is a Java application and can be executed updating the values of the following command template.
 
 ```bash
-sh -c java -Djava.security.egd=file:/dev/./urandom -jar /datahub-webapi-1.6.0.jar"
+sh -c java -Djava.security.egd=file:/dev/./urandom -jar /datahub-webapi-1.7.0.jar"
 ```
 It is important to setup the environment variables before to execute the application.
 
@@ -291,6 +291,8 @@ docker run -p 3006:3006 --rm \
   * Upgrade Java version from 8 to 11.
 * 1.6.0
   * Integration with SonarCloud
+* 1.7.0
+  * Exclude data assets that have been tagged with "its-datahub-hide" in results.
 
 ## Contact information
 Joe Doe : X@Y

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 DataHub Web API to consume data from  DataHub ElasticSearch storage system.
 
 ## Usage
-Once the application is running on a configured port it is required to submit a GET request to retrieve a list of datasets or individual dataset or a POST request to search for **words** or **phrases**.
+Once the application is running on a configured port it is required to submit a GET request to retrieve a list of datasets or individual dataset or a POST request to search for **words** or **phrases**. Results returned will exclude data assets that have been tagged with "its-datahub-hide".
 
 The following endpoints were defined to request for data:
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>datahub</groupId>
 	<artifactId>datahub-webapi</artifactId>
-	<version>1.6.0</version>
+	<version>1.7.0</version>
 	<name>datahub-webapi</name>
 	<description>DataHub Web API</description>
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -5,7 +5,7 @@
 = ITS DataHub
 
 == Web API
-`version: 1.6.0`
+`version: 1.7.0`
 
 WebApi to interface ITS DataHub https://www.elastic.co/products/enterprise-search[ElasticSearch] storage system.
 
@@ -14,9 +14,9 @@ The information is presented through an structure (DataAsset) that contains the 
 === Change Log
 Changes related to the previous version.
 
-`Previous version: 1.5.0`
+`Previous version: 1.6.0`
 
-* Integration with SonarCloud.
+* Exclude data assets that have been tagged with "its-datahub-hide" in results.
 
 === DataAsset
 

--- a/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
+++ b/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
@@ -49,7 +49,10 @@ public class DataAssetDaoImpl implements DataAssetDao {
 	public List<DataAsset> getDataAssets(String sortBy, String sortDirection, Integer limit) throws IOException {
 		SearchRequest searchRequest = new SearchRequest(index);
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-		searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+		searchSourceBuilder.query(
+			QueryBuilders.boolQuery()
+			.mustNot(QueryBuilders.termQuery("tags", "its-datahub-hide"))
+		);
 
 		searchSourceBuilder.size(limit);
 		if (!StringUtils.isEmpty(sortBy)) {
@@ -117,7 +120,11 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		SearchRequest searchRequest = new SearchRequest(index);
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
-		searchSourceBuilder.query(QueryBuilders.multiMatchQuery(searchRequestModel.getTerm(), "name", "description", "tags"));
+		searchSourceBuilder.query(
+			QueryBuilders.boolQuery()
+			.must(QueryBuilders.multiMatchQuery(searchRequestModel.getTerm(), "name", "description", "tags"))
+			.mustNot(QueryBuilders.termQuery("tags", "its-datahub-hide"))	
+		);
 
 		searchSourceBuilder.size(searchRequestModel.getLimit());
 		searchSourceBuilder.sort(new ScoreSortBuilder().order(SortOrder.DESC));
@@ -175,7 +182,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 				"          {\"match_phrase\": { \"name\": { \"query\": \"{{term}}\" } } },\n" +
 				"          {\"match_phrase\": { \"description\": { \"query\": \"{{term}}\" } } },\n" +
 				"          {\"match_phrase\": { \"tags\": { \"query\": \"{{term}}\"} } }\n" +
-				"        ]\n" +
+				"        ],\n" +
 				"        \"filter\": {\"not\": {\"filter\": {\"term\": {\"tags\": \"its-datahub-hide\"}}}}"+
 				"      }\n" +
 				"    },\n" +

--- a/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
+++ b/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
@@ -218,6 +218,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		searchResponseModel.setMaxScore(hits.getMaxScore());
 
 		SearchHit[] searchHits = hits.getHits();
+		searchResponseModel.setNumHits(searchHits.length);
 
 		List<DataAsset> result = new ArrayList<>();
 		for (SearchHit hit : searchHits) {
@@ -247,7 +248,6 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		}
 
 		searchResponseModel.setResult(result);
-		searchResponseModel.setNumHits(result.size());
 
 		return searchResponseModel;
 	}

--- a/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
+++ b/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
@@ -176,6 +176,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 				"          {\"match_phrase\": { \"description\": { \"query\": \"{{term}}\" } } },\n" +
 				"          {\"match_phrase\": { \"tags\": { \"query\": \"{{term}}\"} } }\n" +
 				"        ]\n" +
+				"        \"filter\": {\"not\": {\"filter\": {\"term\": {\"tags\": \"its-datahub-hide\"}}}}"+
 				"      }\n" +
 				"    },\n" +
 				"    \"highlight\" : {\n" +

--- a/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
+++ b/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
@@ -218,12 +218,10 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		searchResponseModel.setMaxScore(hits.getMaxScore());
 
 		SearchHit[] searchHits = hits.getHits();
-		searchResponseModel.setNumHits(searchHits.length);
 
 		List<DataAsset> result = new ArrayList<>();
 		for (SearchHit hit : searchHits) {
 			Map<String, Object> sourceAsMap = hit.getSourceAsMap();
-
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 			DataAsset dataAsset = mapper.convertValue(sourceAsMap, DataAsset.class);
@@ -249,6 +247,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		}
 
 		searchResponseModel.setResult(result);
+		searchResponseModel.setNumHits(result.size());
 
 		return searchResponseModel;
 	}

--- a/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
+++ b/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
@@ -223,6 +223,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		List<DataAsset> result = new ArrayList<>();
 		for (SearchHit hit : searchHits) {
 			Map<String, Object> sourceAsMap = hit.getSourceAsMap();
+			
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 			DataAsset dataAsset = mapper.convertValue(sourceAsMap, DataAsset.class);

--- a/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
+++ b/src/main/java/gov/dot/its/datahub/webapi/dao/DataAssetDaoImpl.java
@@ -41,6 +41,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 	private static final String HIGHLIGHTER_TYPE = "plain";
 	private static final int FRAGMENT_SIZE = 5000;
 	private static final int NUMBER_OF_FRAGMENTS = 5;
+	private static final String MASK_TAG = "its-datahub-hide";
 
 	@Autowired
 	private ESClientDao esClientDao;
@@ -51,7 +52,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 		searchSourceBuilder.query(
 			QueryBuilders.boolQuery()
-			.mustNot(QueryBuilders.termQuery("tags", "its-datahub-hide"))
+			.mustNot(QueryBuilders.termQuery("tags", MASK_TAG))
 		);
 
 		searchSourceBuilder.size(limit);
@@ -123,7 +124,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		searchSourceBuilder.query(
 			QueryBuilders.boolQuery()
 			.must(QueryBuilders.multiMatchQuery(searchRequestModel.getTerm(), "name", "description", "tags"))
-			.mustNot(QueryBuilders.termQuery("tags", "its-datahub-hide"))	
+			.mustNot(QueryBuilders.termQuery("tags", MASK_TAG))	
 		);
 
 		searchSourceBuilder.size(searchRequestModel.getLimit());
@@ -183,7 +184,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 				"          {\"match_phrase\": { \"description\": { \"query\": \"{{term}}\" } } },\n" +
 				"          {\"match_phrase\": { \"tags\": { \"query\": \"{{term}}\"} } }\n" +
 				"        ],\n" +
-				"        \"filter\": {\"not\": {\"filter\": {\"term\": {\"tags\": \"its-datahub-hide\"}}}}"+
+				"        \"filter\": {\"not\": {\"filter\": {\"term\": {\"tags\": \"{{maskTag}}\"}}}}"+
 				"      }\n" +
 				"    },\n" +
 				"    \"highlight\" : {\n" +
@@ -201,6 +202,7 @@ public class DataAssetDaoImpl implements DataAssetDao {
 		Map<String, Object> scriptParams = new HashMap<>();
 		scriptParams.put("term", searchRequestModel.getTerm());
 		scriptParams.put("size", searchRequestModel.getLimit());
+		scriptParams.put("maskTag", MASK_TAG);
 		scriptParams.put("fragmentSize", FRAGMENT_SIZE);
 		scriptParams.put("numFragments", NUMBER_OF_FRAGMENTS);
 		scriptParams.put("highliterType", HIGHLIGHTER_TYPE);


### PR DESCRIPTION
[RDAODTD-2327](https://usdotjpoode.atlassian.net/browse/RDAODTD-2327): Update ITS DataHub Admin API to return only assets without a "mask" tag

At times, an ITS JPO dataset may need to be hidden from ITS DataHub but still be discoverable via data.transportation.gov. This PR will allow us to address this use case quickly by adding a tag to the dataset on data.tranportation.gov while allowing us to keep a catalog of all ITS JPO datasets in our Elasticsearch database.

Since the masked datasets would never be discoverable in ITS DataHub, this PR modifies the endpoints for `datahub-webapi` to never return datasets containing the `its-datahub-hide` tag. The `numHits` field in the search result is intentionally not modified and will still reflect the number of hits from the ElasticSearch result.